### PR TITLE
Make py3.6 compat, handle post_results when nagios endpoint is down.

### DIFF
--- a/libpassiveagent/check.py
+++ b/libpassiveagent/check.py
@@ -63,6 +63,8 @@ def post_results(c, pc, res):
       r = requests.post(u, data=postdata, timeout=10)
     except requests.Timeout:
       logging.warning('Timeout posting results to %s', u)
+    except requests.exceptions.ConnectionError:
+      logging.warning('Connection Error posting results to %s', u)
     else:
       if r.status_code == requests.codes.ok:
         logging.info('Submitted successfully to NRDP: %s', u)


### PR DESCRIPTION
Py3.6 compat is needed for CentOS 7.x / EL7 compatibility - instead of trying to pull in a newer python.

And, don't crash when nagios is down. 