### PR TITLE
in nagios, service name is case sensitive, and %HOSTNAME% expansion 

### DIFF
--- a/libpassiveagent/config.py
+++ b/libpassiveagent/config.py
@@ -33,6 +33,7 @@ def check_command(cmd):
 
 def read_config(c):
   config = configparser.ConfigParser()
+  config.optionxform = lambda option: option
   parsed = {}
   success = False
   for root, dirs, files in os.walk(c['config_dir']):
@@ -64,7 +65,7 @@ def read_config(c):
         c['passive checks'][k] = {}
         s = k.split('|')
         # hostname
-        if s[0] != '%hostname%':
+        if s[0] != '%HOSTNAME%':
           c['passive checks'][k]['hostname'] = s[0]
         else:
           if 'hostname' in c['nrdp']:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = passiveagent
-version = 0.2.1
+version = 0.2.2
 
 [options]
 packages = libpassiveagent

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
   name='passiveagent',
-  version='0.2.1',
+  version='0.2.2',
   install_requires=['requests'],
   packages=['libpassiveagent'],
   scripts=['passiveagent.py']


### PR DESCRIPTION
Nagios service name is case sensitive.  And HOSTNAME expansion in nagios is required to be in uppercase. 

Only affected currently affected 1 real world check, but this there is 36 instances of it.  And this will allow better compatibility for hopefully wider use and adoption.